### PR TITLE
Build fixes, header guards and bugfix

### DIFF
--- a/endian.h
+++ b/endian.h
@@ -1,4 +1,9 @@
+#if !defined( ENDIAN_H_ )
+#define ENDIAN_H_
+
 #include <stddef.h>
 
 void put_bigendian( void *target, unsigned long long value, size_t bytes );
 unsigned long long get_bigendian( const void *target, size_t bytes );
+
+#endif /* ENDIAN_H_ */

--- a/hss_derive.h
+++ b/hss_derive.h
@@ -1,3 +1,6 @@
+#if !defined( HSS_DERIVE_H_ )
+#define HSS_DERIVE_H_
+
 #include "common_defs.h"
 
 /*
@@ -78,4 +81,4 @@ void hss_seed_derive( unsigned char *seed, struct seed_derive *derive,
 /* That structure contains keying data, this makes sure those are cleaned */
 void hss_seed_derive_done( struct seed_derive *derive );
 
-
+#endif /* HSS_DERIVE_H_ */

--- a/hss_internal.h
+++ b/hss_internal.h
@@ -1,5 +1,5 @@
 #if !defined( HSS_INTERNAL_H_ )
-#define HSS_INTERNAL_H
+#define HSS_INTERNAL_H_
 
 #include <stdlib.h>
 #include "common_defs.h"
@@ -80,7 +80,6 @@ struct hss_working_key {
 /* tall trees */
 #endif 
 
-struct subtree *subtree;
 struct merkle_level {
     unsigned level;               /* Total number of levels */
     unsigned h, hash_size;        /* Hash function, width */

--- a/hss_reserve.h
+++ b/hss_reserve.h
@@ -15,6 +15,7 @@ void hss_set_reserve_count(struct hss_working_key *w, sequence_t count);
 bool hss_advance_count(struct hss_working_key *w, sequence_t new_count,
         bool (*update_private_key)(unsigned char *private_key,
                 size_t len_private_key, void *context),
-        void *context);
+        void *context,
+        struct hss_extra_info *info, bool *trash_private_key);
 
 #endif /* HSS_RESERVE_H_ */

--- a/hss_sign.c
+++ b/hss_sign.c
@@ -489,7 +489,7 @@ bool hss_generate_signature(
         struct merkle_level *tree = w->tree[i];
         current_count <<= tree->level;
             /* We subtract 1 because the nonbottom trees are already advanced */
-        current_count += tree->current_index - 1;
+        current_count += (sequence_t)tree->current_index - 1;
     }
     current_count += 1;   /* Bottom most tree isn't already advanced */
 

--- a/hss_thread.h
+++ b/hss_thread.h
@@ -1,3 +1,5 @@
+#if !defined( HSS_THREAD_H_ )
+#define HSS_THREAD_H_
 /*
  * This is our internal abstraction of multithreading; this allows the
  * "application" (in this case, the HSS code) to issue multiple requests that
@@ -129,3 +131,5 @@ void hss_thread_after_write(struct thread_collection *collect);
  * The value passed is the value we'll pass to hss_thread_init
  */
 unsigned hss_thread_num_tracks(int num_threads);
+
+#endif /* HSS_THREAD_H_ */

--- a/hss_verify.h
+++ b/hss_verify.h
@@ -1,3 +1,6 @@
+#if !defined( HSS_VERIFY_H_ )
+#define HSS_VERIFY_H_
+
 #include <stdbool.h>
 
 struct hss_extra_info;
@@ -16,3 +19,5 @@ bool hss_validate_signature(
     const void *message, size_t message_len,
     const unsigned char *signature, size_t signature_len,
     struct hss_extra_info *info);
+
+#endif /* HSS_VERIFY_H_ */

--- a/hss_zeroize.h
+++ b/hss_zeroize.h
@@ -1,5 +1,10 @@
+#if !defined( HSS_ZEROIZE_H_ )
+#define HSS_ZEROIZE_H_
+
 #include <stdlib.h>
 
 /* Zeroize an area, that is, scrub it from holding any potentially secret */
 /* information */
 void hss_zeroize( void *area, size_t len );
+
+#endif /* HSS_ZEROIZE_H_ */

--- a/lm_ots.h
+++ b/lm_ots.h
@@ -1,3 +1,6 @@
+#if !defined( LM_OTS_H_ )
+#define LM_OTS_H_
+
 #include "common_defs.h"
 #include <stddef.h>
 
@@ -57,3 +60,5 @@ bool lm_ots_generate_signature(
 
 /* The include file for the common access routines */
 #include "lm_ots_common.h"
+
+#endif /* LM_OTS_H_ */

--- a/lm_ots_common.h
+++ b/lm_ots_common.h
@@ -1,4 +1,5 @@
 #if !defined( LM_OTS_COMMON_H_ )
+#define LM_OTS_COMMON_H_
 
 #include <stddef.h>
 #include "common_defs.h"

--- a/lm_ots_verify.h
+++ b/lm_ots_verify.h
@@ -1,3 +1,6 @@
+#if !defined( LM_OTS_VERIFY_H_ )
+#define LM_OTS_VERIFY_H_
+
 #include <stddef.h>
 #include "common_defs.h"
 
@@ -16,3 +19,5 @@ bool lm_ots_validate_signature_compute(
     const void *message, size_t message_len, bool prehashed,
     const unsigned char *signature, size_t signature_len,
     param_set_t expected_parameter_set);
+
+#endif /* LM_OTS_VERIFY_H_ */

--- a/test_hss.h
+++ b/test_hss.h
@@ -1,3 +1,6 @@
+#if !defined( TEST_HSS_H_ )
+#define TEST_HSS_H_
+
 #include <stdbool.h>
 
 extern bool test_testvector(bool fast_flag, bool quiet_flag);
@@ -15,3 +18,5 @@ extern bool test_h25(bool fast_flag, bool quiet_flag);
 
 extern bool check_threading_on(bool fast_flag);
 extern bool check_h25(bool fast_flag);
+
+#endif /* TEST_HSS_H_ */


### PR DESCRIPTION
bug was in assigning an underflowing uint_fast32_t to a uint_fast64_t