### PR TITLE
Compile error on hss_generate_root_seed_I_value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+*.a
+demo
+test_hss

--- a/hss.c
+++ b/hss.c
@@ -65,8 +65,7 @@ struct hss_working_key *hss_load_private_key(
  * we don't need to store it in our private key; we can recompute them
  */
 bool hss_generate_root_seed_I_value(unsigned char *seed, unsigned char *I,
-                                    const unsigned char *master_seed,
-                                    param_set_t lm, param_set_t ots) {
+                                    const unsigned char *master_seed) {
 #if SECRET_METHOD == 2
     /* In ACVP mode, we use the master seed as the source for both the */
     /* root seed, and the root I value */

--- a/hss_internal.h
+++ b/hss_internal.h
@@ -176,8 +176,7 @@ bool hss_compress_param_set( unsigned char *compressed,
 /* private seed).  We do this (rather than selecting them  at random) so */
 /* that we don't need to store them in our private key; we can recompute */
 bool hss_generate_root_seed_I_value(unsigned char *seed, unsigned char *I,
-                   const unsigned char *master_seed,
-                   param_set_t parent_lm, param_set_t parent_ots );
+                   const unsigned char *master_seed);
 
 /* Internal function to generate the seed, I value for a child Merkle tree */
 /* (based on the seed, I value of the parent.  We do this (rather than */

--- a/hss_keygen.c
+++ b/hss_keygen.c
@@ -156,8 +156,7 @@ bool hss_generate_private_key(
 
     unsigned char I[I_LEN];
     unsigned char seed[SEED_LEN];
-    if (!hss_generate_root_seed_I_value( seed, I, private_key+PRIVATE_KEY_SEED,
-                                    lm_type[0], lm_ots_type[0])) {
+    if (!hss_generate_root_seed_I_value( seed, I, private_key+PRIVATE_KEY_SEED)) {
         info->error_code = hss_error_internal;
         hss_zeroize( private_key, sizeof private_key );
         return false;


### PR DESCRIPTION
I made master compile again by removing unused parameters from function hss_generate_root_seed_I_value(). I also added a git ignore file to avoid addition of (intermediate) build results.