### PR TITLE
Fix typo in output message of demo.c

### DIFF
--- a/demo.c
+++ b/demo.c
@@ -329,7 +329,7 @@ static int keygen(const char *keyname, const char *parm_set) {
         aux = 0;
     }
 
-    printf( "Generating public key %s (will take a while)\n",
+    printf( "Generating private key %s (will take a while)\n",
                                        private_key_filename );
     if (!hss_generate_private_key(
         do_rand,       /* Routine to generate randomness */


### PR DESCRIPTION
When the private key is generated, the output says,
that the public key is generated.