### PR TITLE
Out-of-bounds memory read in 192 branch when N=24

### DIFF
--- a/hss_verify_inc.c
+++ b/hss_verify_inc.c
@@ -116,11 +116,6 @@ bool hss_validate_signature_init(
     ctx->signature_offset = signature - orig_signature;
     ctx->signature_len = signature_len;
 
-    /* We have the public key in front of us; stash a copy */
-    /* Right now, we have a fixed length public key */
-    /* If that changes, we'll need to investigate the parmaeter set */
-    memcpy( ctx->final_public_key, public_key, 8 + I_LEN + MAX_HASH );
-
     /* Now, initialize the context */
     param_set_t ots_type = get_bigendian( public_key+4, 4 );
 
@@ -132,6 +127,12 @@ bool hss_validate_signature_init(
         return false;
     }
     ctx->h = h;
+
+    /* We have the public key in front of us; stash a copy */
+    /* Right now, we have a fixed length public key */
+    /* If that changes, we'll need to investigate the parmaeter set */
+    memcpy( ctx->final_public_key, public_key, 8 + I_LEN + n );
+
     hss_init_hash_context( h, &ctx->hash_ctx );
     {
         unsigned char prefix[ MESG_PREFIX_MAXLEN ];

--- a/hss_verify_inc.c
+++ b/hss_verify_inc.c
@@ -129,8 +129,6 @@ bool hss_validate_signature_init(
     ctx->h = h;
 
     /* We have the public key in front of us; stash a copy */
-    /* Right now, we have a fixed length public key */
-    /* If that changes, we'll need to investigate the parmaeter set */
     memcpy( ctx->final_public_key, public_key, 8 + I_LEN + n );
 
     hss_init_hash_context( h, &ctx->hash_ctx );


### PR DESCRIPTION
When a keypair is generated with N=24 (e.g. LMS_SHA256_N24_H15/LMOTS_SHA256_N24_W4), the public key generated is of size `4 + (8 + 16 + 24) = 52` bytes.

When the function `hss_validate_signature_init()` begins, it moves the signature pointer up 4 bytes then attempts a memcpy which copies `8 + 16 + 32 = 56` bytes, the signature is currently pointing to `52 - 4 = 48` bytes of memory. This causes an out-of-bounds memory read of `56 - 48 = 8` bytes.

The 8 extra bytes that are read aren't actually used for anything (as far as I'm able to tell), so I don't think it would cause any functional issues to exist, but it is an out-of-bounds memory access which shouldn't occur.

This PR resolves this by using the actual value of `n` which was computed from the `lm_ots_look_up_parameter_set()` call to determine the size of data to copy with `memcpy()`.