### PR TITLE
Fix Windows file mode issue for key file updates

### DIFF
--- a/demo.c
+++ b/demo.c
@@ -147,7 +147,7 @@ bool do_rand( void *output, size_t len ) {
  */
 static bool update_private_key( unsigned char *private_key,
                                size_t len_private_key, void *filename) {
-    FILE *f = fopen( filename, "r+" );
+    FILE *f = fopen( filename, "rb+" );
     if (!f) {
         /* Open failed, possibly because the file didn't exist */
         f = fopen( filename, "wb" );


### PR DESCRIPTION
### Problem
The `fopen` call in `demo.c` line 150 uses text mode (`"r+"`) when opening key files for updates. This causes issues on Windows due to automatic line ending translation:

- When reading: `\r\n` (CRLF) is translated to `\n` (LF)
- When writing: `\n` (LF) is expanded to `\r\n` (CRLF)

This breaks the LMS algorithm when updating the signature counter in key files. For example, when the counter reaches `0x0A`, it gets written as `0x0D0A` instead of just `0x0A`, corrupting the key format and causing signature failures.

### Solution
Changed the file mode from `"r+"` (text mode) to `"rb+"` (binary mode) to prevent automatic line ending translation and ensure byte-for-byte accuracy.

### Changes
- **File:** `demo.c`
- **Line:** 150
- **Change:** `fopen(filename, "r+")` → `fopen(filename, "rb+")`

### Testing
- Compiled successfully on Windows using: `make CC=C:\msys64\ucrt64\bin\gcc.exe AR=C:\msys64\ucrt64\bin\ar.exe CFLAGS="-Wall -O3 -static"`
- All existing functionality preserved
- Binary mode ensures consistent behavior across platforms

### Reproduction Steps (Before Fix)
1. Generate an LMS key pair on Windows
2. Sign multiple messages to increment the counter
3. When counter reaches `0x0A` (or any byte containing `\n`), the key file gets corrupted
4. Subsequent signatures fail due to malformed key data

### Impact
This fix ensures the LMS implementation works correctly on Windows by maintaining binary file integrity for key updates.