### PR TITLE
Change from add to or operation on memcpt_csttome

### DIFF
--- a/hss_aux.c
+++ b/hss_aux.c
@@ -115,7 +115,7 @@ static unsigned memcmp_consttime( const void *a, const void *b, size_t n ) {
     const unsigned char *p = a;
     const unsigned char *q = b;
     while (n--) {
-	sum += *p++ ^ *q++;
+	sum |= *p++ ^ *q++;
     }
     return sum;
 }


### PR DESCRIPTION
# Problem
The `memcmp_consttime` function will keep the difference by incrementing the variable `sum`. This is fairly safe on 32/64 bit systems. The overflow wouldn't happen before 16 millions bytes, which would be an abnormal hash size and probably detected beforehand. But, since the `sum` is typed as `unsigned`, this may lower the difficulty for an attacker to achieve this on 16 bits/8 bits systems. The overflow may be reached starting from 256 bytes, which would be a valid hash size.

# Solution
As provided by the patch, we can mitigate this risk by switching to OR operation instead.